### PR TITLE
log all broadcasted messages; log peername instead of socket_id

### DIFF
--- a/server.jl
+++ b/server.jl
@@ -32,8 +32,10 @@ function start_server(server_host, server_port)
 
     while true
         socket = Sockets.accept(server)
-        socket_id = hash(socket)
-        @info "socket_id $(socket_id) accepted"
+
+        sockname = Sockets.getsockname(socket)
+        peername = Sockets.getpeername(socket)
+        @info "socket accepted, sockname = $(sockname), peername = $(peername)"
 
         @async begin
             try_send(socket, "Enter a nickname")
@@ -66,7 +68,7 @@ function start_server(server_host, server_port)
                 close(socket)
             end
 
-            @info "socket_id $(socket_id) disconnected"
+            @info "socket disconnected, sockname = $(sockname), peername = $(peername)"
         end
     end
 

--- a/server.jl
+++ b/server.jl
@@ -15,6 +15,8 @@ function try_send(socket, message)
 end
 
 function try_broadcast(room, message)
+    @info message
+
     for socket in room
         try_send(socket, message)
     end

--- a/server.jl
+++ b/server.jl
@@ -35,9 +35,8 @@ function start_server(server_host, server_port)
     while true
         socket = Sockets.accept(server)
 
-        sockname = Sockets.getsockname(socket)
         peername = Sockets.getpeername(socket)
-        @info "socket accepted, sockname = $(sockname), peername = $(peername)"
+        @info "socket accepted (peername = $(peername))"
 
         @async begin
             try_send(socket, "Enter a nickname")
@@ -70,7 +69,7 @@ function start_server(server_host, server_port)
                 close(socket)
             end
 
-            @info "socket disconnected, sockname = $(sockname), peername = $(peername)"
+            @info "socket disconnected (peername = $(peername))"
         end
     end
 


### PR DESCRIPTION
1. Log all broadcasted messages
2. Log `peername` instead of `socket_id`